### PR TITLE
Don't depend on napari[all] due to PyQt5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,8 @@ packages = find:
 install_requires =
     leidenalg
     napari-skimage-regionprops
-    napari[all]
+    napari
+    qtpy
     numba>=0.55.2
     numpy>=1.21
     pandas


### PR DESCRIPTION
HI, this plugin depends on `napari[all]`, which ends up bringing PyQt5:
See:
https://github.com/napari/napari/blob/3bf872cbb1df98665fdb7d5e0f3e1a4845a84202/setup.cfg#L97-L106
This is problematic when using conda installed napari, which will have Qt from conda that has a different name (pyqt), breaking the environment. This can happen if the user uses the plugin GUI to install.
Another example is on arm64 macOS where pip doesn't have a wheel for PyQt5, so conda-forge is the only option, because building the binary from source is problematic.
The napari guide for plugins suggests avoiding this:
https://napari.org/stable/plugins/best_practices.html#don-t-include-pyside2-or-pyqt5-in-your-plugin-s-dependencies

So in this PR I've changed the requirement from `napari[all]` to `napari` with the addition of `qtpy`.

Now on my arm64 macOS this package installs with no issues.