### PR TITLE
update ci installation

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -70,9 +70,9 @@ jobs:
         shell: bash -l {0}
         run: |
           python --version
-          conda install -y pyopencl pip setuptools wheel pytest pytest-cov pytest-benchmark pytest-qt pyqt pytest-xvfb pandas
-          conda install -c conda-forge -y python-igraph pytables leidenalg pymeshfix numpy
-          # pip install setuptools tox tox-gh-actions
+          #conda install -y -c conda-forge -y 
+          conda install -y -c conda-forge pyopencl pip setuptools wheel pytest pytest-cov pytest-benchmark pytest-xvfb pandas pytest-qt "pyqt >=5.12.3,!=5.15.0" python-igraph pytables leidenalg pymeshfix numpy 
+          
 
           pip install -e .
       # this runs the platform-specific tests declared in tox.ini


### PR DESCRIPTION
We are no longer installing pyqt with morphometrics (#42), so we need to update the CI installation